### PR TITLE
replace {placeholder}'s with regex

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -70,7 +70,7 @@ define(function(){
       var prefix = config.structure.prefix;
 
       return url.replace(
-        new RegExp('^.*'+(baseUrl + prefix.replace('{module}', ''))),
+        new RegExp('^.*'+(baseUrl + prefix.replace(/{module}/g, ''))),
         '').split('/')[0];
     },
 
@@ -85,7 +85,7 @@ define(function(){
     {
       var prefix = config.structure.prefix;
 
-      return prefix.replace('{module}', 
+      return prefix.replace(/{module}/g, 
         (module || this.getCurrentModule(config, url))
       ) + path;
     },

--- a/src/module.js
+++ b/src/module.js
@@ -26,7 +26,7 @@ define(['base'], function(base){
       }
 
       var path = structure.module.path
-        .replace('{module}', module);
+        .replace(/{module}/g, module);
 
       var reqPath = base.path(path, config, base.getCurrentUrl(req));
 

--- a/src/template.js
+++ b/src/template.js
@@ -20,8 +20,8 @@ define(['base'], function(base){
       }
 
       var path = structure.template.path
-        .replace('{template}', template)
-        .replace('{extension}', extension);
+        .replace(/{template}/g, template)
+        .replace(/{extension}/g, extension);
 
       var module = base.module(name);
 


### PR DESCRIPTION
this way, a path like "/{template}/v1/{template}.{extension}" is handled correctly. 
without regex, just the first {template} is replaced.
